### PR TITLE
Create offset time and match documentation

### DIFF
--- a/MVGLive/mvglive.py
+++ b/MVGLive/mvglive.py
@@ -9,7 +9,7 @@ except NameError:
   unicode = str
 
 class MVGLive(object):
-  def getlivedata(self, station, entries = 10, ubahn = True, tram = True, bus = True, sbahn = True):
+  def getlivedata(self, station, timeoffset= 0, entries = 10, ubahn = True, tram = True, bus = True, sbahn = True):
     productsymbolsurl = 'http://www.mvg-live.de/MvgLive/images/size30/produkt/'
     linesymbolsurl = 'http://www.mvg-live.de/MvgLive/images/size30/linie/'
 
@@ -26,7 +26,7 @@ class MVGLive(object):
               "20589F56B19C8B1615F7A32F69557CD5|"
               "de.swm.mvglive.gwt.client.departureView.GuiAnzeigeService|"
               "getDisplayAbfahrtinfos|java.lang.String/2004016611|I|Z|"
-              + station_str  + "|1|2|3|4|7|5|6|6|7|7|7|7|8|0|" + str(entries) + "|"
+              + station_str  + "|1|2|3|4|7|5|6|6|7|7|7|7|8|" + str(timeoffset) + "|" + str(entries) + "|"
               + str(int(ubahn)) + "|" + str(int(tram)) + "|" + str(int(bus)) + "|" + str(int(sbahn)) + "|")
     headers = {'Content-Type': 'text/x-gwt-rpc; charset=utf-8'}
     r = s.post("http://www.mvg-live.de/MvgLive/mvglive/rpc/guiAnzeigeService", data = payload, headers = headers)

--- a/MVGLive/mvglive.py
+++ b/MVGLive/mvglive.py
@@ -9,7 +9,7 @@ except NameError:
   unicode = str
 
 class MVGLive(object):
-  def getlivedata(self, station, timeoffset= 0, entries = 10, ubahn = True, tram = True, bus = True, sbahn = True):
+  def getlivedata(self, station, timeoffset = 0, entries = 10, ubahn = True, tram = True, bus = True, sbahn = True):
     productsymbolsurl = 'http://www.mvg-live.de/MvgLive/images/size30/produkt/'
     linesymbolsurl = 'http://www.mvg-live.de/MvgLive/images/size30/linie/'
 

--- a/MVGLive/mvglive.py
+++ b/MVGLive/mvglive.py
@@ -26,7 +26,7 @@ class MVGLive(object):
               "20589F56B19C8B1615F7A32F69557CD5|"
               "de.swm.mvglive.gwt.client.departureView.GuiAnzeigeService|"
               "getDisplayAbfahrtinfos|java.lang.String/2004016611|I|Z|"
-              + station_str  + "|1|2|3|4|7|5|6|6|7|7|7|7|8|" + str(timeoffset) + "|" + str(entries) + "|"
+              + station_str  + "|1|2|3|4|7|5|6|6|7|7|7|7|8|" + str(timeoffset*60) + "|" + str(entries) + "|"
               + str(int(ubahn)) + "|" + str(int(tram)) + "|" + str(int(bus)) + "|" + str(int(sbahn)) + "|")
     headers = {'Content-Type': 'text/x-gwt-rpc; charset=utf-8'}
     r = s.post("http://www.mvg-live.de/MvgLive/mvglive/rpc/guiAnzeigeService", data = payload, headers = headers)

--- a/README.md
+++ b/README.md
@@ -2,3 +2,23 @@ PyMVGLive
 =========
 
 Python-Library to get live-data from mvg-live.de - yet another workaround the official, non-released API....
+
+
+## MVGLive.getlivedata()
+Retrieve the next departures from mvg-live.de
+
+Configuration variables:
+ 
+- **station** (*Required*): Name of the stop or station. Visit [the MVG live web site](http://www.mvg-live.de) to find valid names.
+    
+- **timeoffset** (*Optional*): Do not display connections departing sooner than this number of minutes (defaults to 0). Useful if you are a couple of minutes away from the stop.
+    
+- **entries** (*Optional*): Number of entries to retrieve (defaults to 10).
+    
+- **ubahn** (*Optional*): If 'False', do not display U-Bahn (subway) departures
+    
+- **tram** (*Optional*): If 'False', do not display tram departures
+    
+- **bus** (*Optional*): If 'False', do not display bus departures
+    
+- **sbahn** (*Optional*): If 'False', do not display S-Bahn (suburban train) departures


### PR DESCRIPTION
On mvg-live.de, a time offset for walking period can be defined. After reviewing the network requests in Chrome, this changes the parameter before the number of entries.
It would be great being able to define this offset so that results come pre-filtered.